### PR TITLE
Fix user storage formatting and storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Connor Adams",
   "license": "MIT",
   "scripts": {
-    "lint": "yarn tsc --noEmit && eslint . src/*.ts src/storage/*.ts test/*.ts",
+    "lint": "yarn tsc --noEmit && eslint . src/*.ts src/handlers/*.ts src/storage/*.ts test/*.ts",
     "db:install": "serverless plugin install --name serverless-dynamodb-local && serverless dynamodb install",
     "db:start": "serverless dynamodb start",
     "test": "jest",

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
     STATE_SECRET: ${env:STATE_SECRET}
     RESOURCES_TABLE_NAME: ${self:custom.resourcesTableName}
     INSTALLATIONS_TABLE_NAME: ${self:custom.installationsTableName}
+    SERVERLESS_STAGE: ${self:custom.stage}
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -30,7 +31,7 @@ provider:
 
 functions:
   slack-handler:
-    handler: src/slack.handler
+    handler: src/handlers/slack.handler
     events:
       - http:
           method: post

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -151,7 +151,7 @@ app.command(
   handleCommand((command) =>
     lockBot.lock(
       getFirstParam(command.text),
-      `<@${command.user_id}>`, // TODO Move this <@> to message formatting?
+      command.user_id,
       command.channel_id,
       command.team_id
     )
@@ -162,7 +162,7 @@ app.command(
   handleCommand((command) =>
     lockBot.unlock(
       getFirstParam(command.text),
-      `<@${command.user_id}>`, // TODO Move this <@> to message formatting?
+      command.user_id,
       command.channel_id,
       command.team_id
     )

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -11,8 +11,8 @@ import { DocumentClient } from "aws-sdk/clients/dynamodb";
 import { APIGatewayProxyEvent, Context } from "aws-lambda";
 import * as awsServerlessExpress from "aws-serverless-express";
 import * as env from "env-var";
-import LockBot, { Response, Destination } from "./lock-bot";
-import DynamoDBLockRepo from "./storage/dynamodb-lock-repo";
+import LockBot, { Response, Destination } from "../lock-bot";
+import DynamoDBLockRepo from "../storage/dynamodb-lock-repo";
 
 const documentClient = new DocumentClient();
 
@@ -137,29 +137,32 @@ const lockBot = new LockBot(
   )
 );
 
-const getResource = (commandText: string) => commandText.split(" ")[0];
+const prefix =
+  env.get("SERVERLESS_STAGE").required().asString() === "dev" ? "dev" : "";
+
+const getFirstParam = (commandText: string) => commandText.split(" ")[0];
 
 app.command(
-  "/locks",
+  `/${prefix}locks`,
   handleCommand((command) => lockBot.locks(command.channel_id, command.team_id))
 );
 app.command(
-  "/lock",
+  `/${prefix}lock`,
   handleCommand((command) =>
     lockBot.lock(
-      getResource(command.text),
-      `<@${command.user_id}>`,
+      getFirstParam(command.text),
+      `<@${command.user_id}>`, // TODO Move this <@> to message formatting?
       command.channel_id,
       command.team_id
     )
   )
 );
 app.command(
-  "/unlock",
+  `/${prefix}unlock`,
   handleCommand((command) =>
     lockBot.unlock(
-      getResource(command.text),
-      `<@${command.user_id}>`,
+      getFirstParam(command.text),
+      `<@${command.user_id}>`, // TODO Move this <@> to message formatting?
       command.channel_id,
       command.team_id
     )

--- a/src/lock-bot.ts
+++ b/src/lock-bot.ts
@@ -36,8 +36,8 @@ export default class LockBot {
           "How to use `/lock`\n\n" +
           "To lock a resource in this channel called `thingy`, use `/lock thingy`\n\n" +
           "_Example:_\n" +
-          `> *${user}*: \`/lock dev\`\n` +
-          `> *Lockbot*: ${user} has locked \`dev\` 🔒`,
+          `> *<@${user}>*: \`/lock dev\`\n` +
+          `> *Lockbot*: <@${user}> has locked \`dev\` 🔒`,
         destination: "user",
       };
     }
@@ -50,13 +50,13 @@ export default class LockBot {
         };
       }
       return {
-        message: `\`${resource}\` is already locked by ${lockOwner} 🔒`,
+        message: `\`${resource}\` is already locked by <@${lockOwner}> 🔒`,
         destination: "user",
       };
     }
     await this.lockRepo.setOwner(resource, user, channel, team);
     return {
-      message: `${user} has locked \`${resource}\` 🔒`,
+      message: `<@${user}> has locked \`${resource}\` 🔒`,
       destination: "channel",
     };
   };
@@ -73,8 +73,8 @@ export default class LockBot {
           "How to use `/unlock`\n\n" +
           "To unlock a resource in this channel called `thingy`, use `/unlock thingy`\n\n" +
           "_Example:_\n" +
-          `> *${user}*: \`/unlock dev\`\n` +
-          `> *Lockbot*: ${user} has unlocked \`dev\` 🔓`,
+          `> *<@${user}>*: \`/unlock dev\`\n` +
+          `> *Lockbot*: <@${user}> has unlocked \`dev\` 🔓`,
         destination: "user",
       };
     }
@@ -89,12 +89,12 @@ export default class LockBot {
     if (user === lockOwner) {
       await this.lockRepo.delete(resource, channel, team);
       return {
-        message: `${user} has unlocked \`${resource}\` 🔓`,
+        message: `<@${user}> has unlocked \`${resource}\` 🔓`,
         destination: "channel",
       };
     }
     return {
-      message: `Cannot unlock \`${resource}\`, locked by ${lockOwner} 🔒`,
+      message: `Cannot unlock \`${resource}\`, locked by <@${lockOwner}> 🔒`,
       destination: "user",
     };
   };
@@ -109,7 +109,7 @@ export default class LockBot {
     }
     let locksMessage = "Active locks in this channel:\n";
     locks.forEach((lockOwner, lockedResource) => {
-      locksMessage += `> \`${lockedResource}\` is locked by ${lockOwner} 🔒\n`;
+      locksMessage += `> \`${lockedResource}\` is locked by <@${lockOwner}> 🔒\n`;
     });
     return { message: locksMessage.trimRight(), destination: "user" };
   };

--- a/test/lock-bot.test.ts
+++ b/test/lock-bot.test.ts
@@ -28,20 +28,20 @@ const runAllTests = () => {
   };
   test("can lock resource", async () => {
     expect(await execute("/lock dev")).toEqual({
-      message: "Connor has locked `dev` 🔒",
+      message: "<@Connor> has locked `dev` 🔒",
       destination: "channel",
     });
   });
   test("can lock different resource", async () => {
     expect(await execute("/lock test")).toEqual({
-      message: "Connor has locked `test` 🔒",
+      message: "<@Connor> has locked `test` 🔒",
       destination: "channel",
     });
   });
   test("can lock resource with same name in different channels", async () => {
     await execute("/lock dev");
     expect(await execute("/lock dev", { channel: "random" })).toEqual({
-      message: "Connor has locked `dev` 🔒",
+      message: "<@Connor> has locked `dev` 🔒",
       destination: "channel",
     });
   });
@@ -62,7 +62,7 @@ const runAllTests = () => {
   test("cannot lock someone else's resource", async () => {
     await execute("/lock dev");
     expect(await execute("/lock dev", { user: "Dave" })).toEqual({
-      message: "`dev` is already locked by Connor 🔒",
+      message: "`dev` is already locked by <@Connor> 🔒",
       destination: "user",
     });
   });
@@ -72,8 +72,8 @@ const runAllTests = () => {
         "How to use `/lock`\n\n" +
         "To lock a resource in this channel called `thingy`, use `/lock thingy`\n\n" +
         "_Example:_\n" +
-        `> *Connor*: \`/lock dev\`\n` +
-        `> *Lockbot*: Connor has locked \`dev\` 🔒`,
+        `> *<@Connor>*: \`/lock dev\`\n` +
+        `> *Lockbot*: <@Connor> has locked \`dev\` 🔒`,
       destination: "user",
     });
   });
@@ -83,8 +83,8 @@ const runAllTests = () => {
         "How to use `/lock`\n\n" +
         "To lock a resource in this channel called `thingy`, use `/lock thingy`\n\n" +
         "_Example:_\n" +
-        `> *Connor*: \`/lock dev\`\n` +
-        `> *Lockbot*: Connor has locked \`dev\` 🔒`,
+        `> *<@Connor>*: \`/lock dev\`\n` +
+        `> *Lockbot*: <@Connor> has locked \`dev\` 🔒`,
       destination: "user",
     });
   });
@@ -97,14 +97,14 @@ const runAllTests = () => {
   test("can unlock resource", async () => {
     await execute("/lock dev");
     expect(await execute("/unlock dev")).toEqual({
-      message: "Connor has unlocked `dev` 🔓",
+      message: "<@Connor> has unlocked `dev` 🔓",
       destination: "channel",
     });
   });
   test("can unlock different resource", async () => {
     await execute("/lock test");
     expect(await execute("/unlock test")).toEqual({
-      message: "Connor has unlocked `test` 🔓",
+      message: "<@Connor> has unlocked `test` 🔓",
       destination: "channel",
     });
   });
@@ -112,21 +112,22 @@ const runAllTests = () => {
     await execute("/lock dev");
     await execute("/unlock dev", { channel: "random" });
     expect(await execute("/locks")).toEqual({
-      message: "Active locks in this channel:\n> `dev` is locked by Connor 🔒",
+      message:
+        "Active locks in this channel:\n> `dev` is locked by <@Connor> 🔒",
       destination: "user",
     });
   });
   test("cannot unlock someone else's resource", async () => {
     await execute("/lock test");
     expect(await execute("/unlock test", { user: "Dave" })).toEqual({
-      message: "Cannot unlock `test`, locked by Connor 🔒",
+      message: "Cannot unlock `test`, locked by <@Connor> 🔒",
       destination: "user",
     });
   });
   test("cannot unlock someone else's resource (different user and resource)", async () => {
     await execute("/lock dev", { user: "Dave" });
     expect(await execute("/unlock dev")).toEqual({
-      message: "Cannot unlock `dev`, locked by Dave 🔒",
+      message: "Cannot unlock `dev`, locked by <@Dave> 🔒",
       destination: "user",
     });
   });
@@ -136,8 +137,8 @@ const runAllTests = () => {
         "How to use `/unlock`\n\n" +
         "To unlock a resource in this channel called `thingy`, use `/unlock thingy`\n\n" +
         "_Example:_\n" +
-        `> *Connor*: \`/unlock dev\`\n` +
-        `> *Lockbot*: Connor has unlocked \`dev\` 🔓`,
+        `> *<@Connor>*: \`/unlock dev\`\n` +
+        `> *Lockbot*: <@Connor> has unlocked \`dev\` 🔓`,
       destination: "user",
     });
   });
@@ -147,8 +148,8 @@ const runAllTests = () => {
         "How to use `/unlock`\n\n" +
         "To unlock a resource in this channel called `thingy`, use `/unlock thingy`\n\n" +
         "_Example:_\n" +
-        `> *Connor*: \`/unlock dev\`\n` +
-        `> *Lockbot*: Connor has unlocked \`dev\` 🔓`,
+        `> *<@Connor>*: \`/unlock dev\`\n` +
+        `> *Lockbot*: <@Connor> has unlocked \`dev\` 🔓`,
       destination: "user",
     });
   });
@@ -156,7 +157,7 @@ const runAllTests = () => {
     await execute("/lock dev");
     await execute("/unlock dev");
     expect(await execute("/lock dev")).toEqual({
-      message: "Connor has locked `dev` 🔒",
+      message: "<@Connor> has locked `dev` 🔒",
       destination: "channel",
     });
   });
@@ -169,14 +170,15 @@ const runAllTests = () => {
   test("can list locks one lock exists", async () => {
     await execute("/lock dev");
     expect(await execute("/locks")).toEqual({
-      message: "Active locks in this channel:\n> `dev` is locked by Connor 🔒",
+      message:
+        "Active locks in this channel:\n> `dev` is locked by <@Connor> 🔒",
       destination: "user",
     });
   });
   test("can list locks one lock exists different user", async () => {
     await execute("/lock dev", { user: "Dave" });
     expect(await execute("/locks")).toEqual({
-      message: "Active locks in this channel:\n> `dev` is locked by Dave 🔒",
+      message: "Active locks in this channel:\n> `dev` is locked by <@Dave> 🔒",
       destination: "user",
     });
   });
@@ -185,7 +187,7 @@ const runAllTests = () => {
     await execute("/lock test", { user: "Dave" });
     expect(await execute("/locks")).toEqual({
       message:
-        "Active locks in this channel:\n> `dev` is locked by Connor 🔒\n> `test` is locked by Dave 🔒",
+        "Active locks in this channel:\n> `dev` is locked by <@Connor> 🔒\n> `test` is locked by <@Dave> 🔒",
       destination: "user",
     });
   });


### PR DESCRIPTION
`<@`**user**`>` was being added in impractical place. It's a message formatting concern. Not how it should be stored.

![image](https://user-images.githubusercontent.com/10026538/90338319-c476a680-dfe0-11ea-9ed8-794aacb3553c.png)
