### PR TITLE
Use ubuntu-20.04 in CI ⬆

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyse:
     name: Analyse
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
`ubuntu-latest` will be `ubuntu-20.04` soon https://github.com/actions/virtual-environments/issues/1816
Might as well try to upgrade explicitly and make the version number fixed at the same time to avoid surprises in the future