### PR TITLE
Ignore webpack warning for express/lib/view.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,4 +35,10 @@ module.exports = {
     ],
   },
   plugins: [new ESBuildPlugin()],
+  ignoreWarnings: [
+    {
+      module: /node_modules\/express\/lib\/view\.js/,
+      message: /the request of a dependency is an expression/,
+    },
+  ],
 };


### PR DESCRIPTION
* Why: https://github.com/webpack/webpack/issues/1576#issuecomment-418731351
* Fix: https://github.com/webpack/webpack/issues/1576#issuecomment-766796672