### PR TITLE
Update setup-node action to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: '12'
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - name: Setup DynamoDB Local


### PR DESCRIPTION
Why not eh? 🤷‍♂️
https://github.com/actions/setup-node#v2